### PR TITLE
Keep extra metadata in submit

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject scio-api "0.1.3"
+(defproject scio-api "0.1.4"
   :description "API for uploading and downloading documents"
   :url "https://github.com/mnemonic-no/act-scio-api"
   :license {:name "ISC"


### PR DESCRIPTION
To be able to keep data such as links, creation-dates etc. from the
content submit`ed, we need to make a copy of the post data, remove the
actual content and post this to the work queue of Scio.

The main usage area for this is the "creation-date" and "link"/"links"
fields kept from the feed download scripts.