### PR TITLE
Add missing [Unit]

### DIFF
--- a/examples/systemd/scio-api.service
+++ b/examples/systemd/scio-api.service
@@ -1,3 +1,4 @@
+[Unit]
 Description=SCIO API service
 
 [Service]


### PR DESCRIPTION
Add [Unit] to the top of the service-file example, so systemd won't complain as much.